### PR TITLE
after brush finishes, switch to zoom automatically

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -163,7 +163,7 @@ module.exports = biojsvispca = function(init_options){
   };
 
 setup_zoom = function(graph){
-  var  svg = graph.svgForPCA;
+  var svg = graph.svgForPCA;
   var options = graph.options;
   var page_options = graph.page_options;
 
@@ -194,6 +194,7 @@ setup_zoom = function(graph){
   svg.append("rect")
     .attr("width", page_options.width)
     .attr("height", page_options.height)
+    .attr("class", "zoom")
     .style("fill", "none")
     .style("pointer-events", "fill")
     .style("visibility", "hidden")
@@ -204,6 +205,10 @@ setup_zoom = function(graph){
   return graph;
 };
 
+/*
+  Delete existing zoom behavior at brushstart and setup a new one at brushend.
+  This can keep the scale and points' position in consistency.
+*/
 setup_brush = function(graph){
   var svg = graph.svgForPCA;
   var options = graph.options;
@@ -214,6 +219,9 @@ setup_brush = function(graph){
   var brush = d3.svg.brush()
        .x(graph.scaleX)
        .y(graph.scaleY)
+       .on("brushstart", function() { //delete the existing zoom behavior at brushstart
+         d3.selectAll(".zoom").remove();
+       })
        .on("brushend", function() {
          var x = graph.scaleX;
          var y = graph.scaleY;
@@ -264,6 +272,12 @@ setup_brush = function(graph){
 
             d3.event.target.clear();
             d3.select(this).call(d3.event.target);
+
+            // Delete the brush so that we can switch to zoom automatically.
+            d3.selectAll(".brush").remove();
+
+            // Setup a new zoom behavior so that we can zoom and pan the plot after brush finish.
+            setup_zoom(graph);
        });
 
   svg.append("g")
@@ -479,7 +493,6 @@ setup_brush = function(graph){
     var page_options = graph.page_options;
     var positonY = 0;
     var positonXForBrush = page_options.width - 80;
-    var positionForBrush = page_options.width - 160;
 
     svg.append("text")
       .attr("y", positonY)
@@ -491,15 +504,6 @@ setup_brush = function(graph){
         graph = setup_brush(graph);
       });
 
-      svg.append("text")
-        .attr("y", positonY)
-        .attr("x", page_options.width - 80 * 2)
-        .attr("class", "zoomButton")
-        .attr("id", "notToggled")
-        .text("Toggle Zoom")
-        .on("click", function(){
-          graph = setup_zoom(graph);
-        });
     graph = setup_zoom(graph);
 
     graph = setup_scatter(graph);


### PR DESCRIPTION
Hi @rowlandm 
I use zoom as default manipulation. We can toggle brush. After brush finishing, we can switch to zoom automatically. The switch works correctly, no bug.